### PR TITLE
Support Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,18 @@ To test the plugin, you first need to locally publish the plugin.
 Run: `./gradlew publishToMavenLocal`
 This will publish the plugin to the local `/.m2` folder on your machine.
 Add the `mavenLocal` repository to a client project to test this local version,
-which will read from this `/.m2` folder.
+which will read from this `/.m2` folder. To use the local version, declare your dependency as:
+
+```
+buildscript {
+    repositories {
+        mavenLocal()
+    }
+    dependencies {
+        classpath 'com.innovattic.badge:com.innovattic.badge.gradle.plugin:TAG'
+    }
+}
+```
 
 Every time you change the plugin, you need to re-run `./gradlew publishToMavenLocal` in order to update the
 version of the plugin published locally on your machine.
@@ -118,10 +129,9 @@ version of the plugin published locally on your machine.
 ## Developed by
 Sergey Chuprin - <gregamer@gmail.com>
 ## Maintained by
-CleverPumpkin – https://cleverpumpkin.ru
+Innovattic – https://www.innovattic.com/
 ## With contributions from
 Innovattic - https://www.innovattic.com/
 
-Nathan Bruning
-
-Luke Needham
+- Nathan Bruning
+- Luke Needham

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
-import com.android.build.gradle.TestedExtension
-
 buildscript {
     repositories {
-        jcenter()
         google()
         mavenCentral()
     }
@@ -14,7 +11,6 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
         mavenCentral()
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val kotlin = "1.5.30"
     const val gradlePlugin = "7.0.1"
-    const val projectVersion = "1.0.4"
+    const val projectVersion = "1.0.5"
 }
 
 object BuildScriptPlugins {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     google()
     mavenCentral()
 }
@@ -13,6 +12,16 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation(BuildScriptPlugins.android)
+}
+
+// Make sure we're compatible with Java 1.8 and higher, even if we're building on a newer java version
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(8)
+}
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 group = Plugins.appBadgeId

--- a/plugin/src/main/java/ru/cleverpumpkin/appbadge/AppBadgePlugin.kt
+++ b/plugin/src/main/java/ru/cleverpumpkin/appbadge/AppBadgePlugin.kt
@@ -22,23 +22,6 @@ import java.io.File
 @Suppress("unused")
 class AppBadgePlugin : Plugin<Project> {
 
-    init {
-        System.setProperty("java.awt.headless", "true")
-        try {
-            Class.forName(System.getProperty("java.awt.graphicsenv"))
-        } catch (e: ClassNotFoundException) {
-            System.err.println("[WARN] java.awt.graphicsenv: $e")
-            System.setProperty("java.awt.graphicsenv", "sun.awt.CGraphicsEnvironment")
-        }
-
-        try {
-            Class.forName(System.getProperty("awt.toolkit"))
-        } catch (e: ClassNotFoundException) {
-            System.err.println("[WARN] awt.toolkit: $e")
-            System.setProperty("awt.toolkit", "sun.lwawt.macosx.LWCToolkit")
-        }
-    }
-
     override fun apply(project: Project) {
         with(project) {
             extensions.add(PluginExtension.NAME, PluginExtension::class.java)


### PR DESCRIPTION
Make sure the plugin runs on Java 17 by removing a bunch of magic system variable stuff that would give a `NullPointerException`, like in this issue: https://github.com/CleverPumpkin/App-Badge/issues/3

Also tested that the plugin still runs on OpenJDK 11.

Also:

- Remove jcenter references
- When compiling the plugin on newer java versions, make sure the output plugin is backwards compatible up until java 1.8
- Update readme with instructions to test locally